### PR TITLE
CompatHelper: bump compat for Colors to 0.13, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ GameZero = "9da27670-f782-11e9-1da1-f53579315bfe"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Colors = "0.12.11"
+Colors = "0.12.11, 0.13"
 GameZero = "0.3.1"
 StatsBase = "0.34.6"
 julia = "1.6.7"


### PR DESCRIPTION
This pull request changes the compat entry for the `Colors` package from `0.12.11` to `0.12.11, 0.13`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.