### PR TITLE
CompatHelper: bump compat for Colors to 0.13, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Colors = "0.12.11"
+Colors = "0.12.11, 0.13"
 DiscreteMarkovChains = "0.2.1"
 GameZero = "0.3.1"
 Graphs = "1.13.1"


### PR DESCRIPTION
This pull request changes the compat entry for the `Colors` package from `0.12.11` to `0.12.11, 0.13`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.